### PR TITLE
New fileset snapshots and parse IO Freeze in the SQL Error log

### DIFF
--- a/New-FileSetSnapshot.ps1
+++ b/New-FileSetSnapshot.ps1
@@ -1,0 +1,103 @@
+<#
+    .SYNOPSIS
+        Will create a new snapshot of a fileset on a server
+
+    .DESCRIPTION
+        
+    .PARAMETER Server
+        IP address or DNS name to Rubrik Cluster
+    .PARAMETER FileSetName
+        Name of the Fileset created in Rubrik
+    .PARAMETER HostName
+        Name of the server that will be backed up
+    .PARAMETER SLADomain
+        Name of the SLA Domain
+    .PARAMETER CredentialFile
+        Path and filename of encrypted credential file
+
+    .INPUTS
+        None
+
+    .OUTPUTS
+        SUCCESS is a boolean value. $True if snapshot is successfull and $false if not. 
+
+    .EXAMPLE
+        .\New-FileSetSnapshot.ps1 -Server 172.21.8.51 -FileSetName 'Ola Hallengren SQL Backup Files' -HostName cl-sql2012n1.rangers.lab' -SLADomain 'SQL User Databases' -CredentialFile .\CredentialFile.Cred
+
+    .LINK
+        None
+
+    .NOTES
+        Name:       New FIle Set Snapshot
+        Created:    5/2/2018
+        Author:     Chris Lumnah
+        Execution Process:
+            1. Before running this script, you need to create a credential file so that you can securly log into the Rubrik 
+            Cluster. To do so run the below command via Powershell
+
+            $Credential = Get-Credential
+            $Credential | Export-CliXml -Path .\rubrik.Cred"
+            
+            The above will ask for a user name and password and them store them in an encrypted xml file.
+            
+            2. Execute this script via the example above. 
+
+
+
+#>
+param
+(
+    [Parameter(Mandatory=$true,HelpMessage="IP address or DNS name to Rubrik Cluster")]
+    [string]$Server,
+
+    [Parameter(Mandatory=$true,HelpMessage="Name of the Fileset created in Rubrik")]
+    [string]$FileSetName,
+
+    [Parameter(Mandatory=$true,HelpMessage="Name of the server that will be backed up")]
+    [string]$HostName,
+
+    [Parameter(Mandatory=$true,HelpMessage="Name of the SLA Domain")]
+    [string]$SLADomain,
+
+    [Parameter(Mandatory=$true,HelpMessage="Path and filename of encrypted credential file")]
+    [string]$CredentialFile
+)
+
+Import-Module Rubrik
+$Credential = Import-CliXml -Path $CredentialFile
+Connect-Rubrik -Server $Server -Credential $Credential | Out-Null
+
+$RubrikFileSet = Get-RubrikFileset -Name $FileSetName -HostName $HostName
+
+$RubrikRequest = New-RubrikSnapshot -id $RubrikFileSet.id -SLA $SLADomain -Confirm:$false
+
+#Evaluate the request. Based on the status of the Async request, we will show the progress. We will exit if failure or success
+#If failure, we return false, but success we return true
+do
+{
+    $exit = $false
+    $success=$false
+    $Request = Get-RubrikRequest -id $RubrikRequest.id -Type 'fileset'
+
+    switch -Wildcard ($Request.status) 
+    {
+        'QUE*' {Write-Progress -Activity "Backup up fileset $FileSetName on $HostName" -Status $Request.status -percentComplete (0)}
+        'RUN*' 
+        {
+            if ([string]::IsNullOrEmpty($Request.progress)){$PercentComplete = 0} else {$PercentComplete = $Request.progress}
+            Write-Progress -Activity "Backup up fileset $FileSetName on $HostName" -Status $Request.status -percentComplete $PercentComplete
+        }
+        'SUCCEED*' 
+        {
+            $exit = $true 
+            $success = $true
+        }
+        'FAIL*' 
+        {
+            $exit = $true 
+            $success = $false
+        }
+    }
+}until ($exit -eq $true)
+
+$success

--- a/Parse-IOFreeze.ps1
+++ b/Parse-IOFreeze.ps1
@@ -1,0 +1,89 @@
+<#
+    .SYNOPSIS
+        Script to parse the SQL Errorlog for VDI backup operations
+    .DESCRIPTION
+        Script to parse the SQL Errorlog for VDI backup operations. It will scan all of the errorlogs for instances of 
+        'I/O is frozen' - Means the start of the VDI backup
+        'I/O was resumed' - Means the end of the VDI backup
+    .PARAMETER ServerInstance
+        SQL Server Instance name. If default instance, then just use the server name, if a named instance, use either 
+        Server\Instance or Server, port    
+    .PARAMETER OutputFile
+        Path and file name to CSV that will contain the data collected from the Errorlog
+    .INPUTS
+        None
+    .OUTPUTS
+        CSV file 
+    .EXAMPLE
+        Example of how to run the script
+    .LINK
+        None
+    .NOTES
+        Name:       Parse SQL Errorlog for VSS Backups   
+        Created:    1/22/2018
+        Author:     Chris Lumnah
+#>
+param (
+        [Parameter(Mandatory=$true,Position=0)]
+        #SQL Server Instance name. If default instance, then just use the server name, if a named instance, use either 
+        #Server\Instance or Server, port                    
+        [string]
+        $ServerInstance,
+        [Parameter(Mandatory=$true,Position=1)]
+        [AllowEmptyString()]
+        [string]
+        $OutputFile = [environment]::getfolderpath("mydocuments") + "\" + $ServerInstance + "_BackupTimings.csv"
+    )
+
+#Requires -Version 4.0
+#Requires -Modules SQLServer
+
+Import-Module SQLServer
+
+#Use the first line for testing to limit the amount of data back. Use the second line to gather all of the data from the Errorlog
+#$SQLErrorLog = Get-SqlErrorLog -ServerInstance $ServerInstance  -Since Yesterday -Ascending  | Where-Object { $_.Text -match 'I/O is frozen' -or $_.Text -match 'I/O was resumed' } 
+$SQLErrorLog = Get-SqlErrorLog -ServerInstance $ServerInstance -Since LastWeek -Ascending  | Where-Object { $_.Text -match 'I/O is frozen' -or $_.Text -match 'I/O was resumed' }  
+
+$raw = @()
+$output = @()
+foreach ($Entry in $SQLErrorLog)
+{
+    $DatabaseName = ($Entry.Text.split(" "))[5]
+    $DatabaseName = $DatabaseName.replace('.','')
+
+    #Need dates to include milliseconds
+    If ( $Entry.Text -match 'I/O is frozen' ) 
+    {
+        $BackupStartDate = $Entry.Date.ToString("MM/dd/yyyy hh:mm:ss.fff") 
+        $OutputRecord = New-Object PSObject
+        $OutputRecord | Add-Member -type NoteProperty -Name "Database" -Value $DatabaseName
+        $OutputRecord | Add-Member -type NoteProperty -Name "Time" -Value $BackupStartDate
+        $OutputRecord | Add-Member -type NoteProperty -Name "StartEnd" -Value "Start"
+    }
+    
+    If ( $Entry.Text -match 'I/O was resumed' ) 
+    {
+        $BackupEndDate = $Entry.Date.ToString("MM/dd/yyyy hh:mm:ss.fff")
+        $OutputRecord = New-Object PSObject
+        $OutputRecord | Add-Member -type NoteProperty -Name "Database" -Value $DatabaseName
+        $OutputRecord | Add-Member -type NoteProperty -Name "Time" -Value $BackupEndDate
+        $OutputRecord | Add-Member -type NoteProperty -Name "StartEnd" -Value "End"
+    }
+
+   $raw += $OutputRecord
+}
+
+foreach($r in ($raw | Sort-Object database,time)){
+
+    if($r.StartEnd -eq 'Start'){
+        $row = New-Object PSObject -Property @{'Database'=$r.Database;'StartTime'=$r.Time;'EndTime'=$null}
+    } else {
+        $row.EndTime = $r.Time
+        $Output += $row
+    }
+
+} 
+
+Write-Host "Data written to $OutputFile"
+
+$Output | Export-csv -Path $OutputFile -NoTypeInformation


### PR DESCRIPTION
Added new scripts to take a fileset snapshot and to parse the sql error log for io freeze. We can use this analyse for timings.