### PR TITLE
Catching stuff up

### DIFF
--- a/Invoke-DRTest.ps1
+++ b/Invoke-DRTest.ps1
@@ -1,0 +1,78 @@
+﻿#Requires -Version 3 -Module Pester,VMware.VimAutomation.Core,Rubrik
+<#
+  .Example
+  .\Invoke-DRTest.ps1 -Rubrik 172.21.8.51 -vCenter devops-vcsa.rangers.lab -VMName msf-sql2016 -SandboxNetwork '172.21.12.0-dr'
+#>
+param(
+  [String]$Rubrik
+  ,[String]$vCenter
+  ,[String]$VMName
+  ,[String]$SandboxNetwork
+  ,[PSCredential]$RubrikCred       = (Get-Credential -Message 'Rubrik Credentials')
+  ,[PSCredential]$vCenterCred      = (Get-Credential -Message 'vCenter Credentials')
+)
+$MountName = "$VMName-test" 
+
+Describe -Name 'Establish Connectivity' -Fixture {
+  # Connect to Rubrik
+  It -name 'Connect to Rubrik Cluster' -test {
+    Connect-Rubrik -Server $Rubrik -Credential $RubrikCred
+    $rubrikConnection.token | Should Be $true
+  }
+  # Connect to vCenter
+  It -name 'Connect to vCenter Server' -test {
+    Connect-VIServer -Server $vCenter -Credential $vCenterCred
+    $global:DefaultVIServer.SessionId | Should Be $true
+  }
+}
+
+Describe -Name 'Create Live Mount for Sandbox' -Fixture {
+  # Spin up Live Mount
+  It -name 'Request Live Mount' -test {
+  #Populate initial variables
+    $VMID = (Get-RubrikVM -name $VMName -PrimaryClusterID 'local' |  Where-Object {$_.isRelic -ne 'TRUE'}).id
+      
+    (Get-RubrikSnapshot -id $VMID -Date (Get-Date) |
+        New-RubrikMount -MountName $MountName -PowerOn -RemoveNetworkDevices:$false -DisableNetwork:$false -Confirm:$false).id | Should Be $true
+    Start-Sleep -Seconds 1
+  }
+  # Wait for Live Mount to become available in vSphere
+  It -name 'Verify Live Mount is Powered On' -test {
+    while ((Get-VM -Name $MountName -ErrorAction:SilentlyContinue).PowerState -ne 'PoweredOn') 
+    {
+      Start-Sleep -Seconds 1
+    }
+    (Get-VM -Name $MountName).PowerState | Should Be 'PoweredOn'
+  }
+  # Wait for VMware Tools to Start
+  It -name 'Verify VMware Tools are Running' -test {
+    while ((Get-VM $MountName).ExtensionData.Guest.ToolsRunningStatus -ne 'guestToolsRunning') 
+    {
+      Start-Sleep -Seconds 1
+    }
+    (Get-VM $MountName).ExtensionData.Guest.ToolsRunningStatus | Should Be 'guestToolsRunning'
+  }
+  
+  # Connect Live Mount to Sandbox Network
+  It -name 'Move vNIC to Sandbox Network' -test {
+    (Get-NetworkAdapter -VM $MountName | Set-NetworkAdapter -NetworkName $SandboxNetwork -Connected:$true -Confirm:$false).NetworkName | Should Be $SandboxNetwork
+    #Sleep for IP to be assigned
+    Start-Sleep -Seconds 30
+  }
+
+}
+
+
+Describe -Name 'Sandbox Tests' -Fixture {
+  # Make sure VM is alive
+  It -name "$MountName Test 1 - Network Responds to Ping" -test {
+    Test-Connection -ComputerName (Get-VM -Name $MountName).Guest.IPAddress[0] -Quiet | Should Be 'True'
+  }
+}
+
+Describe -Name 'Remove Mount' -Fixture {
+  It -name "Unmounting $MountName" -test{
+    $req = Get-RubrikMount -VMID $VMID | Remove-RubrikMount -Confirm:$false
+  }
+    
+}

--- a/Measure-IOFreeze.ps1
+++ b/Measure-IOFreeze.ps1
@@ -1,0 +1,96 @@
+<#
+    .SYNOPSIS
+        Script to parse the SQL Errorlog for VDI backup operations
+    .DESCRIPTION
+        Script to parse the SQL Errorlog for VDI backup operations. It will scan all of the errorlogs for instances of 
+        'I/O is frozen' - Means the start of the VDI backup
+        'I/O was resumed' - Means the end of the VDI backup
+    .PARAMETER ServerInstance
+        SQL Server Instance name. If default instance, then just use the server name, if a named instance, use either 
+        Server\Instance or Server, port    
+    .PARAMETER OutputFile
+        Path and file name to CSV that will contain the data collected from the Errorlog
+    .INPUTS
+        None
+    .OUTPUTS
+        CSV file 
+    .EXAMPLE
+        Example of how to run the script
+    .LINK
+        None
+    .NOTES
+        Name:       Parse SQL Errorlog for VSS Backups   
+        Created:    2018-10-28
+        Author:     Mike Fal (modified from Parse-IOFreeze by Chris Lumnah)
+
+#>
+param (
+        [Parameter(Mandatory=$true,Position=0)]
+        #SQL Server Instance name. If default instance, then just use the server name, if a named instance, use either 
+        #Server\Instance or Server, port                    
+        [string]
+        $ServerInstance,
+        [datetime]$After = (Get-Date).AddDays(-7),
+        [datetime]$Before = (Get-Date),
+        [switch]$OutputRaw
+    )
+
+#Requires -Version 4.0
+#Requires -Modules SQLServer
+
+Import-Module SQLServer
+
+#Use the first line for testing to limit the amount of data back. Use the second line to gather all of the data from the Errorlog
+#$SQLErrorLog = Get-SqlErrorLog -ServerInstance $ServerInstance  -Since Yesterday -Ascending  | Where-Object { $_.Text -match 'I/O is frozen' -or $_.Text -match 'I/O was resumed' } 
+$SQLErrorLog = Get-SqlErrorLog -ServerInstance $ServerInstance -After $After -Before $Before -Ascending  | Where-Object { $_.Text -match 'I/O is frozen' -or $_.Text -match 'I/O was resumed' }  
+
+$raw = @()
+$rawdata = @()
+$output = @()
+foreach ($Entry in $SQLErrorLog)
+{
+    $DatabaseName = ($Entry.Text.split(" "))[5]
+    $DatabaseName = $DatabaseName.replace('.','')
+
+    #Need dates to include milliseconds
+    If ( $Entry.Text -match 'I/O is frozen' ) 
+    {
+        $BackupStartDate = $Entry.Date.ToString("MM/dd/yyyy hh:mm:ss.fff tt") 
+        $OutputRecord = New-Object PSObject
+        $OutputRecord | Add-Member -type NoteProperty -Name "Database" -Value $DatabaseName
+        $OutputRecord | Add-Member -type NoteProperty -Name "Time" -Value $BackupStartDate
+        $OutputRecord | Add-Member -type NoteProperty -Name "StartEnd" -Value "Start"
+    }
+    
+    If ( $Entry.Text -match 'I/O was resumed' ) 
+    {
+        $BackupEndDate = $Entry.Date.ToString("MM/dd/yyyy hh:mm:ss.fff tt")
+        $OutputRecord = New-Object PSObject
+        $OutputRecord | Add-Member -type NoteProperty -Name "Database" -Value $DatabaseName
+        $OutputRecord | Add-Member -type NoteProperty -Name "Time" -Value $BackupEndDate
+        $OutputRecord | Add-Member -type NoteProperty -Name "StartEnd" -Value "End"
+    }
+
+   $raw += $OutputRecord
+}
+
+foreach($r in ($raw | Sort-Object database,time)){
+
+    if($r.StartEnd -eq 'Start'){
+        $row = New-Object PSObject -Property @{'Database'=$r.Database;'StartTime'=(Get-Date $r.Time);'EndTime'=$null;'DurationMS'=$null}
+    } else {
+        $row.EndTime = (Get-Date $r.Time)
+        $row.DurationMS = ((Get-Date $row.EndTime) - (Get-Date $row.StartTime)).TotalMilliseconds
+        $rawdata += $row
+    }
+} 
+if($OutputRaw){
+    return $rawdata
+} else {
+  foreach($db in ($rawdata | Group-Object -Property Database).Name){
+    $FreezeAgg = $rawdata | Where-Object Database -eq $db | Measure-Object DurationMS -Average -Minimum -Maximum
+    $Aggdata = [ordered]@{'Database'=$db;'AverageDurationMS'=$FreezeAgg.Average;'MinimumDurationMS'=$FreezeAgg.Minimum;'MaximumDurationMS'=$FreezeAgg.Maximum}
+    $output += New-Object PSObject -Property $Aggdata
+  }
+  return $output
+}

--- a/SQLMVOps.ps1
+++ b/SQLMVOps.ps1
@@ -1,0 +1,44 @@
+﻿<#
+    .SYNOPSIS
+        Script to start or stop Rubrik Managed volume ops
+    .DESCRIPTION
+        Simple script to start or stop Rubrik Managed Volume operations. Intended to be used in a Windows
+        environment to "wrap around" a backup job that is being directed to a managed volume.
+
+        To use this script, it requires a credential file to be created on the machine and under the account that
+        will execute the script. To do this, log into the specified machine under the appropriate account and run:
+        Get-Credential | Export-CliXml <Path to credential file location>
+
+        The credential you will use is the *Rubrik credential*, not the windows credential. This file will be used by the
+        script to connect to Rubrik and run the Managed Volume scripts.
+
+        Once you've set the credentail file path in the script, also enter the IP address for the Rubrik cluster.
+
+    .PARAMETER mvname
+        Managed Volume name   
+    .PARAMETER Start
+        Switch to start Managed Volume snapshot, mutually exclusiave of Stop
+    .PARAMETER Stop
+        Switch to start Managed Volume snapshot, mutually exclusiave of Stop
+    .EXAMPLE
+        .\SQLMVOps -mvname FOO -Start
+
+        Start a snapshot for Managed Volume FOO
+
+    .NOTES  
+        Created:    2018-10-28
+        Author:     Mike Fal
+
+#>
+param([Parameter(Mandatory=$true)]
+      [string]$mvname
+     ,[Switch]$Start
+     ,[Switch]$Stop)
+
+$RubrikCluster = '0.0.0.0'
+$CredFile = 'E:\SQLOla\rubrikcred_ola.xml'
+
+Connect-Rubrik -Server $RubrikCluster -Credential (Import-Clixml $CredFile) | Out-Null
+
+if($Start){Get-RubrikManagedVolume -Name $mvname | Start-RubrikManagedVolumeSnapshot}
+if($stop){Get-RubrikManagedVolume -Name $mvname | Stop-RubrikManagedVolumeSnapshot}

--- a/invoke-RubrikSqlMvBackup.ps1
+++ b/invoke-RubrikSqlMvBackup.ps1
@@ -1,0 +1,28 @@
+﻿param([String]$MVName
+      ,[String]$ServerInstance
+      ,[String]$Database
+      ,[switch]$DeleteOld
+      ,[switch]$script
+      ,[int]$MaxTransferSize
+      ,[int]$BufferCount)
+
+$i=0
+$mv = Get-RubrikManagedVolume -Name $MVName
+$files = $mv.mainExport.channels | 
+    ForEach-Object {$i++;"DISK='\\$($_.ipaddress)\$($_.mountpoint)\$Database`_$i`_$(Get-Date -Format 'yyyyMMddHHmmss').bak'"}
+
+$sql = "BACKUP DATABASE [$Database] TO " + ($files -join ',') + " WITH INIT,COMPRESSION,STATS=10"
+if($MaxTransferSize){$sql+=",MAXTRANSFERSIZE=$MaxTransferSize"}
+if($BufferCount){$sql+=",BUFFERCOUNT=$BufferCount"}
+if($script){
+    Write-Output $sql
+} else {
+$mv | Start-RubrikManagedVolumeSnapshot
+if($DeleteOld){
+    foreach($channel in $mv.mainExport.channels){
+        Get-ChildItem -Path "\\$($channel.ipaddress)\$($channel.mountpoint)\$Database_*.bak" | Remove-Item -Force
+    }
+}
+    sqlcmd -S $ServerInstance -Q $sql
+    $mv | Stop-RubrikManagedVolumeSnapshot
+}

--- a/invoke-RubrikSqlMvRestore.ps1
+++ b/invoke-RubrikSqlMvRestore.ps1
@@ -1,0 +1,33 @@
+﻿param([String]$MVName
+      ,[String]$ServerInstance
+      ,[String]$Database
+      ,[switch]$Replace
+      ,[switch]$script
+      ,[datetime]$SnapshotDate
+      ,[int]$MaxTransferSize
+      ,[int]$BufferCount
+      ,[int]$BufferSize)
+
+if($SnapshotDate -eq $null){$SnapshotDate = (Get-Date)}
+Get-RubrikManagedVolume -Name $MVName | 
+    Get-RubrikSnapshot -Date $SnapshotDate.ToUniversalTime() | 
+    Sort-Object data -Descending | 
+    Select-Object -First 1 | 
+    New-RubrikManagedVolumeExport -Confirm:$false |Out-Null
+
+#pause for live mount
+Start-Sleep -Seconds 60
+$mv = Get-RubrikManagedVolumeExport -SourceManagedVolumeName $mvname
+$files = $mv.channels |
+    ForEach-Object {$f = get-childitem "\\$($_.ipaddress)\$($_.mountpoint)\*.bak" | Sort-Object lastwritetime -Descending | Select-Object -First 1;Write-Output "DISK='$($f.FullName)'"}
+
+$sql = "RESTORE DATABASE [$Database] FROM " + ($files -join ',') + " WITH STATS=10"
+if($Replace){$sql += ",REPLACE"}
+if($MaxTransferSize){$sql+=",MAXTRANSFERSIZE=$MaxTransferSize"}
+if($BufferCount){$sql+=",BUFFERCOUNT=$BufferCount"}
+if($BufferSize){$sql+=",BUFFERCOUNT=$BufferSize"}
+if($script){
+    Write-Output $sql
+} else {
+    sqlcmd -S $ServerInstance -Q $sql
+}

--- a/invoke-masssqlrestore.ps1
+++ b/invoke-masssqlrestore.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules Rubrik
+﻿#Requires -Modules Rubrik, SqlServer
 param([Parameter(Mandatory=$true)]
       [string[]]$databases
      ,[Parameter(Mandatory=$true)]
@@ -7,8 +7,15 @@ param([Parameter(Mandatory=$true)]
       [String]$TargetInstance
      ,[string]$TargetDataFilePath
      ,[string]$TargetLogFilePath
+     ,[Switch]$Replace
      )
 
+$sql_temp = "IF EXISTS (SELECT 1 FROM sys.databases WHERE name='<DBNAME>')
+BEGIN
+ALTER DATABASE [<DBNAME>] SET OFFLINE WITH ROLLBACK IMMEDIATE;
+ALTER DATABASE [<DBNAME>] SET ONLINE;
+DROP DATABASE [<DBNAME>];
+END"     
 $Target = Get-RubrikSQLInstance -ServerInstance $TargetInstance
 $dbs = Get-RubrikDatabase -ServerInstance $SourceInstance |
        Where-Object {$databases -contains $_.name -and $_.isRelic -ne 'TRUE' -and $_.isLiveMount -ne 'TRUE'} |
@@ -16,6 +23,11 @@ $dbs = Get-RubrikDatabase -ServerInstance $SourceInstance |
 $reqs = @()
 
 foreach($db in $dbs){
+    if($Replace){
+        $sql = $sql_temp.Replace('<DBNAME>',$db.name)
+        Invoke-Sqlcmd -ServerInstance $TargetInstance -Database master -Query $sql
+        New-RubrikHost -Name $TargetInstance -Confirm:$false | Out-Null
+    }
     $reqs += Export-RubrikDatabase -Id $db.id `
                           -RecoveryDateTime (Get-Date $db.latestRecoveryPoint) `
                           -FinishRecovery `

--- a/invoke-sqlondemand.ps1
+++ b/invoke-sqlondemand.ps1
@@ -1,4 +1,7 @@
-﻿param($ServerInstance)
+﻿param( [Parameter(ParameterSetName='standalone')]
+     $ServerInstance
+     , [Parameter(ParameterSetName='AG')]
+     $agname)
 
 #Parse ServerInstance 
 if($ServerInstance -contains '\'){
@@ -9,7 +12,11 @@ if($ServerInstance -contains '\'){
     $InstanceName = 'MSSQLSERVER'
 }
 
-$dbs = Get-RubrikDatabase -Hostname $HostName -Instance $InstanceName | Get-RubrikDatabase | Where-Object {$_.isrelic -ne 'TRUE' -and $_.isLiveMount -ne 'TRUE'}
+if($agname){
+    $dbs = Get-RubrikDatabase -Hostname $agname | Get-RubrikDatabase | Where-Object {$_.isrelic -ne 'TRUE' -and $_.isLiveMount -ne 'TRUE'}
+} else {
+    $dbs = Get-RubrikDatabase -Hostname $HostName -Instance $InstanceName | Get-RubrikDatabase | Where-Object {$_.isrelic -ne 'TRUE' -and $_.isLiveMount -ne 'TRUE'}
+}
 
 $dbs = $dbs | Select-Object name,recoveryModel,effectiveSLADomainName,latestRecoveryPoint,id | 
     Sort-Object name | 


### PR DESCRIPTION
Updates to
- Invoke-MassSqlRestore.ps1 (added -Replace switch for overwrite)
- Invoke-SqlOnDemand.ps1 (adding -AGName)
- Added Invoke-DRTest.ps1, modified from a Wahl script to perform a simple VM DR test
- Invoke-RubrikSqlMvBackup.ps1 and Invoke-RubrikSqlMvRestore.ps1 to backup and restore dbs off of MVs(5.0)
- Measure-IoFreeze.ps1 (from Parse-IOFreeze.ps1) for consolidated IO Freeze reporting
- SQLMVOps.ps1 to manage MV operations in a SQL Agent backup job